### PR TITLE
Bugfix: fixed minor bug, & added color

### DIFF
--- a/client/src/components/DetailedRecord/DetailedRecord.jsx
+++ b/client/src/components/DetailedRecord/DetailedRecord.jsx
@@ -29,6 +29,7 @@ function DetailedRecord({ submission, iconSize, timerType }) {
       { submission.approve ? 
         <div className="inline-icon">
           <CheckIcon 
+            color="success"
             fontSize={ iconSize }
             titleAccess="This submission has been approved by a moderator."
           />

--- a/client/src/components/SubmissionHandler/SubmissionHandler.jsx
+++ b/client/src/components/SubmissionHandler/SubmissionHandler.jsx
@@ -45,7 +45,7 @@ function SubmissionHandler({ imageReducer, isUnapproved }) {
     if (games) {
       const sorted = isUnapproved ? games.toSorted((a, b) => b.unapproved - a.unapproved) : games.toSorted((a, b) => b.reported - a.reported);
       setSortedGames(sorted);
-      setGame(sorted[0]);
+      setGame(game ? game : sorted[0]);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [games, isUnapproved]);


### PR DESCRIPTION
The bug involved an unnecessary state update in the moderator hub submission handler, where, whenever an action was performed on the submission, the list of submissions would always reload with the game with the most submissions, regardless of the game selected.

I also added a green color to the approved submission checkmarks.