### PR TITLE
Rendering newlines within post body

### DIFF
--- a/client/src/components/SubmissionDetails/ReportForm/ReportForm.jsx
+++ b/client/src/components/SubmissionDetails/ReportForm/ReportForm.jsx
@@ -46,7 +46,7 @@ function ReportForm({ updateBoard }) {
             { /* Report form information - tell the user about reporting this submission */ }
             <h2>If this submission has issues, report it here.</h2>
             <p>In your message, please explain your reasoning for reporting the submission. Be specific!</p>
-            <p>You have <b>{ user.profile.report_token }</b> reports left. Report counts reset in <CountdownTimer />.</p>
+            <p>You have <b>{ user.profile.report_token }</b> reports left. Report count resets in <CountdownTimer />.</p>
             
             { /* Report form - allow user to leave a message with the report */ }
             <form onSubmit={ (e) => handleReport(e, submission, setSubmitting, updateBoard) }>

--- a/client/src/pages/Home/NewsPost.jsx
+++ b/client/src/pages/Home/NewsPost.jsx
@@ -27,10 +27,10 @@ function NewsPost({ post }) {
         { post.body.map((line, index) => {
           return <p key={ index }>{ line }</p>;
         })}
-        { post.link && post.link.length > 0 &&
-          <a href={ post.link } target="_blank" rel="noopener noreferrer">{ post.link_description }</a>
-        }
       </div>
+      { post.link && post.link.length > 0 &&
+        <a href={ post.link } target="_blank" rel="noopener noreferrer">{ post.link_description }</a>
+      }
       
     </details>
   );

--- a/client/src/pages/Home/NewsPost.module.css
+++ b/client/src/pages/Home/NewsPost.module.css
@@ -9,5 +9,11 @@
 }
 
 .body {
-    margin-bottom: 10px;
+    --line-height: 19px;
+    padding-bottom: var(--line-height);
+}
+
+.body p {
+    min-height: var(--line-height);
+    margin: 0;
 }

--- a/client/src/pages/News/News.module.css
+++ b/client/src/pages/News/News.module.css
@@ -2,6 +2,11 @@
     padding: var(--app-padding);
 }
 
+.news h2 {
+    margin: 0;
+    padding: 10px 0;
+}
+
 .post {
     background-color: rgb(var(--color-container));
     margin: 10px 0;
@@ -10,5 +15,15 @@
 }
 
 .post hr {
-    margin: 20px 0;
+    margin: 15px 0;
+}
+
+.body {
+    --line-height: 19px;
+    padding-bottom: var(--line-height);
+}
+
+.body p {
+    min-height: var(--line-height);
+    margin: 0;
 }

--- a/client/src/pages/News/NewsPost.jsx
+++ b/client/src/pages/News/NewsPost.jsx
@@ -21,9 +21,11 @@ function NewsPost({ post }) {
       <hr />
 
       { /* Post body - render the contents of the post, as well as a link, if one was included */ }
-      { post.body.map((line, index) => {
-        return <p key={ index }>{ line }</p>;
-      })}
+      <div className={ styles.body }>
+        { post.body.map((line, index) => {
+          return <p key={ index }>{ line }</p>;
+        })}
+      </div>
       { post.link && post.link.length > 0 &&
         <a href={ post.link } target="_blank" rel="noopener noreferrer">{ post.link_description }</a>
       }


### PR DESCRIPTION
Before, the way I was rendering post bodies was handling any number of `\n` characters as just a single `\n` character. This meant that the line-spacing created by the author was not correctly being rendered, although it was correctly preserved in the database. Thus, I just needed to make a few front-end adjustments to correct this issue.