### PR TITLE
Relax submission contraints

### DIFF
--- a/client/src/pages/Levelboard/Insert/Insert.jsx
+++ b/client/src/pages/Levelboard/Insert/Insert.jsx
@@ -108,7 +108,7 @@ function Insert({ level, updateBoard, submitting, setSubmitting, board }) {
                 disableFuture
                 label="Date"
                 format="YYYY-MM-DD"
-                minDate={ dayjs(game.release_date) }
+                minDate={ game.custom ? dayjs("2016-07-09") : dayjs(game.release_date) }
                 value={ form.values.submitted_at ? dayjs(form.values.submitted_at) : form.values.submitted_at }
                 onChange={ handleSubmittedAtChange }
                 slotProps={{

--- a/client/src/pages/Levelboard/Update/Update.jsx
+++ b/client/src/pages/Levelboard/Update/Update.jsx
@@ -130,7 +130,7 @@ function Update({ level, updateBoard, submitting, setSubmitting }) {
             disableFuture
             label="Date"
             format="YYYY-MM-DD"
-            minDate={ dayjs(game.release_date) }
+            minDate={ game.custom ? dayjs("2016-07-09") : dayjs(game.release_date) }
             value={ form.values.submitted_at ? dayjs(form.values.submitted_at) : form.values.submitted_at }
             onChange={ handleSubmittedAtChange }
             slotProps={{

--- a/supabase/migrations/20240204202432_relax_submission_contraints.sql
+++ b/supabase/migrations/20240204202432_relax_submission_contraints.sql
@@ -1,0 +1,46 @@
+DROP POLICY IF EXISTS "Insert restrictions [RESTRICTIVE]" ON submission;
+
+CREATE POLICY "Insert restrictions [RESTRICTIVE]" 
+ON submission
+AS RESTRICTIVE 
+FOR INSERT 
+TO authenticated
+WITH CHECK (
+  (
+    (id = now()) 
+  AND
+    CASE get_chart_type(game_id, level_id)
+      WHEN 'both'::text THEN true
+      WHEN 'score'::text THEN score
+      WHEN 'time'::text THEN (NOT score)
+      ELSE false
+    END 
+  AND
+    valid_monkey_platform_region(game_id, monkey_id, platform_id, region_id)
+  AND (
+      submitted_at >= (SELECT release_date FROM game WHERE abb = game_id) 
+      OR 
+      (SELECT custom FROM game WHERE abb = game_id)
+    )
+  )
+);
+
+DROP POLICY IF EXISTS "Update restrictions [RESTRICTIVE]" ON submission;
+
+CREATE POLICY "Update restrictions [RESTRICTIVE]"
+ON submission 
+AS RESTRICTIVE 
+FOR UPDATE 
+TO authenticated 
+USING (true) 
+WITH CHECK (
+  (
+    valid_monkey_platform_region(game_id, monkey_id, platform_id, region_id)
+  AND
+    (
+      submitted_at >= (SELECT release_date FROM game WHERE abb = game_id) 
+      OR 
+      (SELECT custom FROM game WHERE abb = game_id)
+    )
+  )
+);


### PR DESCRIPTION
Another "hotfix" update. The purpose of this update is to reduce the `submitted_at` constraints for custom games. Before, any submissions to the website had to *at minimum* be equal to the release date of the game record associated with `game_id`. Now, this standard only holds for main games. 