### PR TITLE
MOD: add millisecond timers

### DIFF
--- a/client/src/helper/FrontendHelper.js
+++ b/client/src/helper/FrontendHelper.js
@@ -79,21 +79,28 @@ const FrontendHelper = () => {
     // PRECONDITIONS (2 parameters):
     // 1.) record is a float number with at most two decimals places
     // 2.) type is either "score" or "time"
+    // 3.) decimalPlaces is an integer, specifying how many decimal places we should round to, typically this is 2.
+    // this parameter is only relevant when the type is "time"
     // POSTCONDITION (2 possible outcome):
     // if the type is time, we will compute the hours, minuntes, seconds, and centiseconds, and return a string with the
-    // following format: [X...X]X:XX:XX.XX
+    // following format: X[X...X]:XX:XX.XX
     // if the type is score, return a string representing a formatted integer (includes commas)
-    const secondsToHours = (record, type) => {
+    const secondsToHours = (record, type, decimalPlaces = 2) => {
         if (type === "time") {
             // calculate each unit of time
             let time = Math.floor(record);
             let hours = Math.floor(time/3600).toLocaleString("en-US", { minimumIntegerDigits: 1, useGrouping: false });
             let minutes = Math.floor((time%3600)/60).toLocaleString("en-US", { minimumIntegerDigits: 2, useGrouping: false });
             let seconds = Math.floor(time%60).toLocaleString("en-US", { minimumIntegerDigits: 2, useGrouping: false });
-            let centiseconds = Math.round((record%60-seconds)*100).toLocaleString("en-US", { minimumIntegerDigits: 2, useGrouping: false });
 
-            // return with following format: XX:XX:XX.XX
-            return `${ hours }:${ minutes }:${ seconds }.${ centiseconds }`;
+            let multiplier = Math.pow(10, decimalPlaces);
+            let decimals = Math.round((record%60-seconds)*multiplier).toLocaleString("en-US", {
+                minimumIntegerDigits: decimalPlaces,
+                useGrouping: false
+            });
+
+            // return with following format: X[X...X]:XX:XX.X[X...X]
+            return `${ hours }:${ minutes }:${ seconds }.${ decimals }`;
         }
 
         // otherwise, just return formatted record
@@ -102,22 +109,29 @@ const FrontendHelper = () => {
 
     // FUNCTION 6: secondsToMinutes - convert a time from seconds to minutes
     // PRECONDITIONS (2 parameters):
-    // 1.) record is a float number with at most two decimals places
+    // 1.) record is a float number with at most three decimals places
     // 2.) type is either "score" or "time"
+    // 3.) decimalPlaces is an integer, specifying how many decimal places we should round to, typically this is 2.
+    // this parameter is only relevant when the type is "time"
     // POSTCONDITION (2 possible outcome):
-    // if the type is time, we will compute the minuntes, seconds, and centiseconds, and return a string with the
-    // following format: [X...X]X:XX.XX
+    // if the type is time, we will compute the minuntes, seconds, and decimals, and return a string with the
+    // following format: X[X...X]:XX.X[X...X]
     // if the type is score, return a string representing a formatted integer (includes commas)
-    const secondsToMinutes = (record, type) => {
+    const secondsToMinutes = (record, type, decimalPlaces = 2) => {
         if (type === "time") {
             // calculate each unit of time
             let time = Math.floor(record);
             let minutes = Math.floor(time/60).toLocaleString("en-US", { minimumIntegerDigits: 1, useGrouping: false });
             let seconds = Math.floor(time%60).toLocaleString("en-US", { minimumIntegerDigits: 2, useGrouping: false });
-            let centiseconds = Math.round((record%60-seconds)*100).toLocaleString("en-US", { minimumIntegerDigits: 2, useGrouping: false });
 
-            // return with following format: XX:XX:XX.XX
-            return `${ minutes }:${ seconds }.${ centiseconds }`;
+            let multiplier = Math.pow(10, decimalPlaces);
+            let decimals = Math.round((record%60-seconds)*multiplier).toLocaleString("en-US", { 
+                minimumIntegerDigits: decimalPlaces, 
+                useGrouping: false 
+            });
+
+            // return with following format: X[X...X]:XX.X[X...X]
+            return `${ minutes }:${ seconds }.${ decimals }`;
         }
 
         // otherwise, just return formatted record
@@ -143,12 +157,16 @@ const FrontendHelper = () => {
                     return Math.floor(fixedRecord);
                 case "sec_csec":
                     return fixedRecord.toFixed(2);
+                case "sec_msec":
+                    return fixedRecord.toFixed(3);
                 case "min":
                     return secondsToMinutes(fixedRecord, type).split(":")[0];
                 case "min_sec":
                     return secondsToMinutes(fixedRecord, type).split(".")[0];
                 case "min_sec_csec":
                     return secondsToMinutes(fixedRecord, type);
+                case "min_sec_msec":
+                    return secondsToMinutes(fixedRecord, type, 3);
                 case "hour":
                     return secondsToHours(fixedRecord, type).split(":")[0];
                 case "hour_min":
@@ -158,6 +176,8 @@ const FrontendHelper = () => {
                     return secondsToHours(fixedRecord, type).split(".")[0];
                 case "hour_min_sec_csec":
                     return secondsToHours(fixedRecord, type);
+                case "hour_min_sec_msec":
+                    return secondsToHours(fixedRecord, type, 3);
                 default:
                     return fixedRecord.toFixed(2);
             };
@@ -206,9 +226,9 @@ const FrontendHelper = () => {
     // POSTCONDITIONS (1 possible outcome):
     // the highest unit of time of the timer type is return as a string
     const timerType2TimeUnit = timerType => {
-        if (["sec", "sec_csec"].includes(timerType)) return "second";
-        if (["min", "min_sec", "min_sec_csec"].includes(timerType)) return "minute";
-        if (["hour", "hour_min", "hour_min_sec", "hour_min_sec_csec"].includes(timerType)) return "hour";
+        if (["sec", "sec_csec", "sec_msec"].includes(timerType)) return "second";
+        if (["min", "min_sec", "min_sec_csec", "min_sec_msec"].includes(timerType)) return "minute";
+        if (["hour", "hour_min", "hour_min_sec", "hour_min_sec_csec", "hour_min_sec_msec"].includes(timerType)) return "hour";
         return undefined;
     };
 

--- a/client/src/helper/GameHelper.js
+++ b/client/src/helper/GameHelper.js
@@ -143,7 +143,7 @@ const GameHelper = () => {
         return modes;
     };
 
-    // FUNCTION 5: fetchLevelFromGame: given a game object, level name, & category, determine if the level is present in the object, and
+    // FUNCTION 5: fetchLevelFromGame - given a game object, level name, & category, determine if the level is present in the object, and
     // return it
 	// PRECONDITIONS (4 parameters):
 	// 1.) game: an object containing information about the game defined in the path
@@ -166,7 +166,25 @@ const GameHelper = () => {
 		return null;
 	};
 
-    return { cleanGameObject, getGameCategories, getCategoryTypes, getRelevantModes, fetchLevelFromGame };
+    // TODO: this is a fine temporary solution, but should be generalized better - need to rework timer system!
+    // FUNCTION 6: getDecimals - function that takes an array of levels, and determines the decimals
+    // PRECONDITIONS (1 parameter):
+    // 1.) levels: an array of level objects, each should contain the `timer_type` field, or this function WILL fail!
+    // POSTCONDITIONS (2 possible outcomes):
+    // if even a single level exists with a `timer_type` ending in 'msec', we return 3
+    // otherwise, return 2
+    const getDecimals = levels => {
+        return levels.some(level => level.timer_type !== null && level.timer_type.endsWith("msec")) ? 3 : 2;
+    };
+
+    return { 
+        cleanGameObject,
+        getGameCategories,
+        getCategoryTypes,
+        getRelevantModes,
+        fetchLevelFromGame,
+        getDecimals
+    };
 };
 
 /* ===== EXPORTS ===== */

--- a/client/src/pages/Game/Rule/Rule.jsx
+++ b/client/src/pages/Game/Rule/Rule.jsx
@@ -10,8 +10,8 @@ function Rule({ rule }) {
   /* ===== RULE COMPONENT ===== */
   return (
     <li>
-      { splitRule(rule).map(line => {
-        return <p key={ line }>{ line }</p>;
+      { splitRule(rule).map((line, index) => {
+        return <p key={ `${ line }_${ index }` }>{ line }</p>;
       })}
     </li>
   );

--- a/client/src/pages/Levelboard/Insert/RecordInput.jsx
+++ b/client/src/pages/Levelboard/Insert/RecordInput.jsx
@@ -92,6 +92,22 @@ function RecordInput({ form, handleChange, timerType, type }) {
           variant="filled"
         />
       }
+      { timerType.includes("msec") &&
+        <TextField
+          color={ form.error.millisecond ? "error" : "primary" }
+          fullWidth
+          helperText={ form.error.millisecond ? form.error.millisecond : null }
+          id="millisecond"
+          inputProps={ { 
+            inputMode: "numeric",
+            pattern: "[0-9]*",
+          } }
+          label="Decimals"
+          onChange={ handleChange }
+          value={ form.values.millisecond }
+          variant="filled"
+        />
+      }
     </>
   );
   

--- a/client/src/pages/Totalizer/Totalizer.js
+++ b/client/src/pages/Totalizer/Totalizer.js
@@ -1,6 +1,7 @@
 /* ===== IMPORTS ===== */
 import { MessageContext } from "../../utils/Contexts"; 
 import { useContext, useState } from "react";
+import GameHelper from "../../helper/GameHelper";
 import RPCRead from "../../database/read/RPCRead";
 
 const Totalizer = () => {
@@ -16,6 +17,9 @@ const Totalizer = () => {
 
     // database functions
     const { getTotals } = RPCRead();
+
+    // helper functions
+    const { getDecimals } = GameHelper();
 
     // FUNCTION 1: fetchTotals - given a game, category, & type, use the submissions to generate a totals object
     // PRECONDITIONS (3 parameters):
@@ -43,10 +47,20 @@ const Totalizer = () => {
         };
     };
 
-    return { 
-        totals,
-        fetchTotals
+    // TODO: this is a fine temporary solution, but should be generalized better - need to rework timer system!
+    // FUNCTION 2: getDecimalsByCategory - given a game object and category, determine the decimals of the category
+    // PRECONDITIONS (2 parameter):
+    // 1.) game: an object containing information about the game defined in the path
+    // 2.) category: a string value representing a valid category
+    // POSTCONDITIONS (2 possible outcomes):
+    // if even a single level exists with a `timer_type` ending in 'msec', we return 3
+    // otherwise, return 2
+    const getDecimalsByCategory = (game, category) => {
+        const categoryLevels = game.mode.filter(mode => mode.category === category).map(mode => mode.level).flat(1);
+        return getDecimals(categoryLevels);
     };
+
+    return { totals, fetchTotals, getDecimalsByCategory };
 };
 
 /* ===== EXPORTS ===== */

--- a/client/src/pages/Totalizer/Totalizer.jsx
+++ b/client/src/pages/Totalizer/Totalizer.jsx
@@ -53,10 +53,8 @@ function Totalizer({ imageReducer }) {
   const [pageNum, setPageNum] = useState(1);
 
   // states and functions from the js file
-  const {
-    totals,
-    fetchTotals
-  } = TotalizerLogic();
+  const { totals, fetchTotals, getDecimalsByCategory } = TotalizerLogic();
+  const decimalPlaces = getDecimalsByCategory(game, category);
 
   // FUNCTION 1: handleTableStateChange - code that executes each time the user toggles the table state
   // PRECONDITIONS: NONE
@@ -131,7 +129,14 @@ function Totalizer({ imageReducer }) {
                   numCols={ TABLE_LENGTH }
                 >
                   { totals[tableState].slice((pageNum-1)*USERS_PER_PAGE, pageNum*USERS_PER_PAGE).map(row => {
-                    return <TotalizerRow row={ row } topTotal={ totals[tableState][0].total } imageReducer={ imageReducer } key={ row.profile.id } />
+                    return (
+                      <TotalizerRow 
+                        row={ row } 
+                        topTotal={ totals[tableState][0].total } 
+                        imageReducer={ imageReducer } key={ row.profile.id }
+                        decimalPlaces={ decimalPlaces }
+                      />
+                    );
                   })}
                 </TableContent>
               :

--- a/client/src/pages/Totalizer/TotalizerRow.jsx
+++ b/client/src/pages/Totalizer/TotalizerRow.jsx
@@ -4,7 +4,7 @@ import styles from "./Totalizer.module.css";
 import DetailedUsername from "../../components/DetailedUsername/DetailedUsername.jsx";
 import FrontendHelper from "../../helper/FrontendHelper.js";
 
-function TotalizerRow({ row, topTotal, imageReducer }) {
+function TotalizerRow({ row, topTotal, imageReducer, decimalPlaces }) {
   /* ===== FUNCTIONS ===== */
 
   // helper functions
@@ -14,7 +14,7 @@ function TotalizerRow({ row, topTotal, imageReducer }) {
   const location = useLocation();
   const type = location.pathname.split("/")[5];
   const difference = type === "score" ? topTotal-row.total : row.total-topTotal;
-  const totalDifference = secondsToHours(difference, type);
+  const totalDifference = secondsToHours(difference, type, decimalPlaces);
 
   /* ===== TOTALIZER ROW COMPONENT ===== */
   return (
@@ -25,7 +25,7 @@ function TotalizerRow({ row, topTotal, imageReducer }) {
       </td>
       <td>
         <div className={ styles.total }>
-          { secondsToHours(row.total, type) }
+          { secondsToHours(row.total, type, decimalPlaces) }
           { row.position !== 1 && 
             <span 
               className={ styles.difference }

--- a/client/src/pages/UserStats/Stats/Total.jsx
+++ b/client/src/pages/UserStats/Stats/Total.jsx
@@ -3,7 +3,7 @@ import { useLocation } from "react-router-dom";
 import styles from "./Stats.module.css";
 import FrontendHelper from "../../../helper/FrontendHelper";
 
-function Total({ total, filter }) {
+function Total({ total, filter, decimalPlaces }) {
   /* ===== VARIABLES ====== */
   const location = useLocation();
   const path = location.pathname.split("/");
@@ -32,7 +32,7 @@ function Total({ total, filter }) {
             <tbody>
               <tr>
                 <td>{ total.position }</td>
-                <td>{ secondsToHours(total.total, type) }</td>
+                <td>{ secondsToHours(total.total, type, decimalPlaces) }</td>
               </tr>
             </tbody>
 

--- a/client/src/pages/UserStats/UserStats.js
+++ b/client/src/pages/UserStats/UserStats.js
@@ -36,7 +36,6 @@ const UserStats = (decimalPlaces) => {
             levels = levels.concat(set.map(ranking => ranking.level));
         });
 
-        console.log(levels);
         decimalPlaces.current = getDecimals(levels);
     };
 

--- a/client/src/pages/UserStats/UserStats.js
+++ b/client/src/pages/UserStats/UserStats.js
@@ -1,9 +1,10 @@
 /* ===== IMPORTS ===== */
 import { MessageContext } from "../../utils/Contexts";
 import { useContext, useState } from "react";
+import GameHelper from "../../helper/GameHelper";
 import RPCRead from "../../database/read/RPCRead";
 
-const UserStats = () => {
+const UserStats = (decimalPlaces) => {
     /* ===== CONTEXTS ===== */
 
     // add message function from message context
@@ -17,7 +18,29 @@ const UserStats = () => {
     // database functions
     const { getTotals, getMedals, getUserRankings } = RPCRead();
 
-    // FUNCTION 1: fetchUserStats - given path information & game object, fetch the stats object
+    // helper functions
+    const { getDecimals } = GameHelper();
+
+    // TODO: this is a fine temporary solution, but should be generalized better - need to rework timer system!
+    // FUNCTION 1: determineDecimals - given the rankings object, determine the decimals of the category
+    // PRECONDITIONS (1 parameter):
+    // 1.) rankings: an object containing information about the user's ranking on every level in the category
+    // POSTCONDITIONS (2 possible outcomes):
+    // if even a single level exists with a `timer_type` ending in 'msec', set `decimalPlaces.current` to 3
+    // otherwise, set `decimalPlaces.current` to 2
+    const determineDecimals = rankings => {
+        const levelSets = Object.values(rankings);
+        let levels = [];
+
+        levelSets.forEach(set => {
+            levels = levels.concat(set.map(ranking => ranking.level));
+        });
+
+        console.log(levels);
+        decimalPlaces.current = getDecimals(levels);
+    };
+
+    // FUNCTION 2: fetchUserStats - given path information & game object, fetch the stats object
     // PRECONDITIONS (3 parameters):
     // 1.) game: an object containing information about the game defined in the path
     // 2.) profileId: an integer representing the id of the user who's info we want to query
@@ -62,6 +85,7 @@ const UserStats = () => {
                     total: liveTotal
                 }
             };
+            determineDecimals(allRankings);
             setStats(stats);
 
         } catch (error) {

--- a/client/src/pages/UserStats/UserStats.jsx
+++ b/client/src/pages/UserStats/UserStats.jsx
@@ -1,6 +1,6 @@
 /* ===== IMPORTS ===== */
 import { CategoriesContext, ProfileContext, MessageContext } from "../../utils/Contexts";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import styles from "./UserStats.module.css";
 import Container from "../../components/Container/Container.jsx";
@@ -44,15 +44,17 @@ function UserStats() {
   }
   const errorMessage = "User page does not exist.";
 
+  /* ===== REFS ===== */
+
+  // use this to store decimalPlaces, which can only be calculated after data fetch
+  const decimalPlaces = useRef(null);
+
   /* ===== STATES & FUNCTIONS ===== */
   const [game, setGame] = useState(undefined);
   const [allLiveFilter, setAllLiveFilter] = useState("live");
 
   // hooks and functions from the js file
-  const { 
-    stats,
-    fetchUserStats
-  } = UserStatsLogic();
+  const { stats, fetchUserStats } = UserStatsLogic(decimalPlaces);
 
   /* ===== EFFECTS ===== */
 
@@ -122,7 +124,7 @@ function UserStats() {
           { /* Stats tables - render these only if it's a practice mode category */ }
           { isPracticeMode &&
             <>
-              <Total total={ stats[allLiveFilter].total } filter={ allLiveFilter } />
+              <Total total={ stats[allLiveFilter].total } filter={ allLiveFilter } decimalPlaces={ decimalPlaces.current } />
               <hr />
               <Medals medals={ stats[allLiveFilter].medals } filter={ allLiveFilter } />
               <hr />

--- a/supabase/migrations/20240625111448_add_new_timer.sql
+++ b/supabase/migrations/20240625111448_add_new_timer.sql
@@ -1,0 +1,64 @@
+ALTER TYPE timer_t ADD VALUE 'sec_msec' AFTER 'sec_csec';
+ALTER TYPE timer_t ADD VALUE 'min_sec_msec' AFTER 'min_sec_csec';
+ALTER TYPE timer_t ADD VALUE 'hour_min_sec_msec' AFTER 'hour_min_sec_csec';
+
+-- Need to redefine this function to include new timer types
+CREATE OR REPLACE FUNCTION prepare_submission() RETURNS "trigger"
+LANGUAGE "plpgsql"
+AS $$
+  DECLARE
+    negative_transform public.chart_t;
+    level_timer_type public.timer_t;
+  BEGIN
+    -- First, let's quickly validate that user is trying to insert a positive record. The value may be transformed to a negative
+    -- value by this function, but should NEVER begin as negative
+    IF NEW.record < 0 THEN
+      RAISE EXCEPTION 'Record cannot be a negative value.';
+    END IF;
+
+    -- ascending -> `negative_transform`, timer_type -> `level_timer_type`
+    SELECT ascending, timer_type
+    INTO negative_transform, level_timer_type
+    FROM level l
+    WHERE l.game = NEW.game_id AND l.name = NEW.level_id AND l.category = NEW.category;
+
+    -- If the submission is for a time chart, let's perform any necessary record modifications based on both the 
+    -- `time_negative_transform` and `level_timer_time`
+    IF NOT new.score THEN
+
+      -- Apply any transformations based on the `level_timer_type` variable
+      IF NOT (level_timer_type IN ('sec_csec', 'sec_msec', 'min_sec_csec', 'min_sec_msec', 'hour_min_sec_csec', 'hour_min_sec_msec')) THEN
+        NEW.record := FLOOR(NEW.record); -- Round down to the nearest second
+      END IF;
+      IF level_timer_type IN ('min', 'hour', 'hour_min') THEN
+        NEW.record := (FLOOR(NEW.record / 60)) * 60::float8; -- Round down to nearest minute
+      END IF;
+      IF level_timer_type = 'hour' THEN
+        NEW.record := (FLOOR(NEW.record / 3600)) * 3600::float8; -- Round down to nearest hour
+      END IF;
+
+      -- Apply any transformations based on the `negative_transform` variable
+      IF negative_transform IN ('time'::chart_t, 'both'::chart_t) THEN
+        NEW.record := NEW.record * (-1); -- negate the record attribute
+      END IF;
+
+    -- Otherwise, let's perform any necessary record modifications based on the `negative_transform` variable
+    ELSE
+      IF negative_transform IN ('score'::chart_t, 'both'::chart_t) THEN
+        NEW.record := NEW.record * (-1); -- negate the record attribute
+      END IF;
+    END IF;
+
+    -- Set the all_position in the submission table
+    NEW.all_position := get_position(NEW, FALSE);
+
+    -- Set the position in the submission table if live is true
+    IF NEW.live = true THEN
+      NEW.position := get_position(NEW, TRUE);
+    ELSE
+      NEW.position := null;
+    END IF;
+
+    RETURN NEW;
+  END;
+$$;


### PR DESCRIPTION
The newest Monkey Ball game, `Super Monkey Ball: Banana Rumble`, is the first game in the series to have millisecond-level precision. Unfortunately for me, the website was not prepared for this, so I have written this patch to support specifiable millisecond-level precision.

This was not the cleanest solution, mostly because the system that determines how to render different timer types is quite bad, and does not scale well. It requires both front-end and back-end code changes to add a timer type, which is quite a headache. In the future, I would like to rework this system, but for now, this works...