### PR TITLE
FIX: admins can now upload games with charts that have empty timer types

### DIFF
--- a/client/src/pages/GameAddSummary/GameAddSummary.js
+++ b/client/src/pages/GameAddSummary/GameAddSummary.js
@@ -56,6 +56,7 @@ const GameAddSummary = (setError, setSubmitting) => {
             }
             level.game = abb;
             level.mode = level.mode.name;
+            level.timer_type = level.timer_type ? level.timer_type : null;
             return level;
         });
 


### PR DESCRIPTION
Fixes bug that caused games with empty timer types to fail on upload. Edge case I must have missed, oops!