### PR TITLE
FIX: allow 59 second submissions (> instead of >=)

### DIFF
--- a/client/src/pages/Levelboard/Insert/Insert.js
+++ b/client/src/pages/Levelboard/Insert/Insert.js
@@ -272,7 +272,7 @@ const Insert = (level, setSubmitting) => {
             "hour_min_sec", 
             "hour_min_sec_csec", 
             "hour_min_sec_msec"
-        ].includes(timerType) && second >= MAX_SECOND) {
+        ].includes(timerType) && second > MAX_SECOND) {
             return `This field cannot exceed the value ${ MAX_SECOND }.`;
         }
 


### PR DESCRIPTION
A user encountered a bug where they were unable to submit a 59 second time, which is of course a valid time:
![6GGx56j](https://github.com/user-attachments/assets/f88a444c-2855-4e6b-8712-fdce91f6ae59)
I suspected the issue was due to wrong comparison, and thankfully, it was that simple (`>=` instead of `>`).